### PR TITLE
FIX: the re-SUBSCRIBE timer is updated each time it receives a NOTIFY

### DIFF
--- a/src/tinyMEDIA/src/tmedia_session_jsep.js
+++ b/src/tinyMEDIA/src/tmedia_session_jsep.js
@@ -416,7 +416,7 @@ function tmedia_session_jsep01(o_mgr) {
     };
 
     if (tsk_utils_get_navigator_friendly_name() == 'firefox') {
-        tmedia_session_jsep01.mozThis = this; // FIXME: no longer needed? At least not needed on FF 34.05
+        //tmedia_session_jsep01.mozThis = this; // FIXME: no longer needed? At least not needed on FF 34.05
         this.o_media_constraints.mandatory.MozDontOfferDataChannel = true;
     }
 }

--- a/src/tinySIP/src/dialogs/tsip_dialog.js
+++ b/src/tinySIP/src/dialogs/tsip_dialog.js
@@ -1017,9 +1017,15 @@ tsip_dialog.prototype.get_newdelay = function (o_message) {
         if ((o_hdr_state = o_message.get_header(tsip_header_type_e.Subscription_State))) {
             if (o_hdr_state.i_expires > 0) {
                 i_expires = o_hdr_state.i_expires;
-                b_found = true;
             }
         }
+
+        /* RFC6665 :
+         *   Note well that this "expires" value is a
+         *   parameter on the "Subscription-State" header field NOT the
+         *   "Expires" header field.
+         */
+        b_found = true;
     }
 
     /* Expires header */

--- a/src/tinySIP/src/dialogs/tsip_dialog_generic__subscribe.js
+++ b/src/tinySIP/src/dialogs/tsip_dialog_generic__subscribe.js
@@ -70,8 +70,14 @@ function tsip_dialog_generic_Any_2_Any_X_iNotify(ao_args) {
      }
 
      // update timeout using expires from subscription state (e.g. 'Subscription-State: pending;expires=200')
-     o_dialog.i_timerRefresh = o_dialog.get_newdelay(o_request);
-	 o_dialog.timer_schedule('generic', 'Refresh');
+	 var i_newdelay = o_dialog.get_newdelay(o_request);
+
+     // The notifier MAY use this mechanism to shorten a subscription;
+     // however, this mechanism MUST NOT be used to lengthen a subscription
+     if ( i_newdelay < o_dialog.i_timerRefresh ) {
+        o_dialog.i_timerRefresh = i_newdelay;
+        o_dialog.timer_schedule('generic', 'Refresh');
+     }
 
      // alert user
      o_dialog.signal_i(tsip_event_code_e.DIALOG_REQUEST_INCOMING, 'Incoming NOTIFY', o_request);

--- a/src/tinySIP/src/tsip_session.js
+++ b/src/tinySIP/src/tsip_session.js
@@ -226,6 +226,7 @@ tsip_session.prototype.__set = function (ao_params) {
                     if ((o_message = o_curr.ao_values[0])) {
                         if (o_message.o_hdr_From && o_message.o_hdr_From.o_uri) {
                             this.o_uri_from = o_message.o_hdr_From.o_uri.clone(false, false);
+                            this.o_uri_from.s_display_name = o_message.o_hdr_From.s_display_name;
                         }
                         if (o_message.o_hdr_To && o_message.o_hdr_To.o_uri) {
                             this.o_uri_to = o_message.o_hdr_To.o_uri.clone(false, false);


### PR DESCRIPTION
Asterisk server does not send an "expires" parameter on a "Subscription-State" header, so every NOTIFY message refreshes the re-subscription timer

> recv=NOTIFY sips:3304@df7jal23ls0d.invalid;rtcweb-breaker=no;click2call=no;transport=wss SIP/2.0
> Via: SIP/2.0/WS 10.10.10.10;rport;branch=z9hG4bK589ae874
> From: <sip:4117@ext-local>;tag=as30003ff1
> To: "Arkady"<sip:3304@server>;tag=Sf0ILSLDcPkiL452fLJx
> Contact: <sip:4117@10.10.10.10;transport=WS>
> Call-ID: fe3536f6-4862-9d89-3087-83ddaef00431
> CSeq: 105 NOTIFY
> Content-Type: application/pidf+xml
> Content-Length: 482
> Max-Forwards: 70
> User-Agent: FPBX-13.0.61.4(13.7.2)
> Subscription-State: active
> Event: presence




